### PR TITLE
Failing to properly codegen enums with certain IDs

### DIFF
--- a/generator/src/main/scala-2.11/com/meituan/firefly/Generator.scala
+++ b/generator/src/main/scala-2.11/com/meituan/firefly/Generator.scala
@@ -268,7 +268,7 @@ class Generator(defaultNameSpace: String = "thrift", output: File = new File("ge
       ("elems" -> (if (enum.elems.isEmpty) Seq()
       else {
         val lastElem = enum.elems.last
-        (for (elem <- enum.elems.dropRight(1)) yield Map("name" -> elem._1.name, "id" -> elem._2)) :+
+        (for (elem <- enum.elems.dropRight(1)) yield Map("name" -> elem._1.name, "id" -> elem._2.toString)) :+
           Map("name" -> lastElem._1.name, "id" -> lastElem._2.toString, "last" -> true)
       }))
   }


### PR DESCRIPTION
Execution of codegen for

```
enum EnumCodeGenTest {
    NAME_1 = 1000
    NAME_2 = 10000
    NAME_2 = 102
}
```

Produces
```
public enum EnumCodeGenTest {
    NAME_2(102),NAME_1(1,000),NAME_2(10000); // won't compile
    private final static Map<Integer, EnumCodeGenTest> map = new HashMap<Integer, EnumCodeGenTest>();
    static {
        map.put(102, NAME_2);
        map.put(1,000, NAME_1);  // won't compile
        map.put(10000, NAME_2);
        }
    private final int value;
    private EnumCodeGenTest (int value) {
        this.value = value;
    }

    public int getValue(){ return value; }

    public static EnumCodeGenTest findByValue(int value) { return map.get(value); }
}
```

The PR should fix it. Please review. 